### PR TITLE
Fixed requries that were not changed after rename to lib/em/mqtt

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Synopsis
 --------
 
     require 'rubygems'
-    require 'em-mqtt'
+    require 'em/mqtt'
     
     # Publish example
     EventMachine.run do

--- a/examples/eventmachine_publish.rb
+++ b/examples/eventmachine_publish.rb
@@ -3,7 +3,7 @@
 $:.unshift File.dirname(__FILE__)+'/../lib'
 
 require 'rubygems'
-require 'em-mqtt'
+require 'em/mqtt'
 
 include EventMachine::MQTT
 

--- a/examples/eventmachine_subscribe.rb
+++ b/examples/eventmachine_subscribe.rb
@@ -3,7 +3,7 @@
 $:.unshift File.dirname(__FILE__)+'/../lib'
 
 require 'rubygems'
-require 'em-mqtt'
+require 'em/mqtt'
 
 EventMachine.run do
   EventMachine::MQTT::ClientConnection.connect('test.mosquitto.org') do |c|


### PR DESCRIPTION
I had the same problems as in issue #3 after commit a0bbda5618dd691b032966f7b7791e2ffaffc318

Changing the requires from `em-mqtt` to `em/mqtt` does the trick.
