### PR TITLE
Prevent error swallowing inside of EM (closes #13)

### DIFF
--- a/lib/em/mqtt/client_connection.rb
+++ b/lib/em/mqtt/client_connection.rb
@@ -106,7 +106,8 @@ class EventMachine::MQTT::ClientConnection < EventMachine::MQTT::Connection
   def unbind
     timer.cancel if timer
     unless state == :disconnecting
-      raise MQTT::NotConnectedException.new("Connection to server lost")
+      # Re-throw any exceptions (if present) to avoid swallowed errors.
+      raise $! || MQTT::NotConnectedException.new("Connection to server lost")
     end
     @state = :disconnected
   end

--- a/lib/em/mqtt/version.rb
+++ b/lib/em/mqtt/version.rb
@@ -1,5 +1,5 @@
 module EventMachine
   module MQTT
-    VERSION = "0.0.4"
+    VERSION = "0.0.5"
   end
 end


### PR DESCRIPTION
# Why?

 * The current version of `em-mqtt` regards almost all runtime exceptions as `MQTT::NotConnectedException`s

# What Changed?

 * Instead of always triggering `MQTT::NotConnectedException` on unbind, re-raise any unhandled exceptions.
 * Bumped version so its ready to publish. Let me know if you prefer I change it back.

# Notes

 * This method won't preserve stack traces, but it gives more information than what is available at present.
 * Closes #13 

Please let me know if you would like me to touch anything up. 